### PR TITLE
use task_name for mode

### DIFF
--- a/aics_im2im/utils/template_utils.py
+++ b/aics_im2im/utils/template_utils.py
@@ -182,9 +182,8 @@ def log_hyperparameters(object_dict: dict) -> None:
     hparams["seed"] = cfg.get("seed")
 
     # send hparams to all loggers
-    mode = "train" if trainer.training else "test"
     for logger in trainer.loggers:
-        logger.log_hyperparams(hparams, mode=mode)
+        logger.log_hyperparams(hparams, mode=cfg.task_name)
 
 
 def get_metric_value(metric_dict: dict, metric_name: str) -> float:


### PR DESCRIPTION
For more recent pytorch lightning versions, `trainer.training` does not seem to be `True` upon instantiation, so we shouldn't rely on it to determine the `mode` inside `log_hyperparameters`. We have access to `cfg.task_name` so we can use that instead