### PR TITLE
save last and best model

### DIFF
--- a/aics_im2im/loggers/mlflow.py
+++ b/aics_im2im/loggers/mlflow.py
@@ -114,8 +114,20 @@ class MLFlowLogger(_MLFlowLogger):
                     local_path=os.path.join(ckpt_callback.dirpath, ckpt),
                     artifact_path=artifact_path,
                 )
-        else:
+
+            # also save the current best model as "best.ckpt"
             filepath = ckpt_callback.best_model_path
+            best_path = Path(filepath).with_name("best.ckpt")
+            os.link(filepath, best_path)
+
+            self.experiment.log_artifact(
+                self.run_id, local_path=best_path, artifact_path=artifact_path
+            )
+
+            os.unlink(best_path)
+
+        else:
+            filepath = ckpt_callback.last_model_path
             artifact_path = "checkpoints"
 
             # mimic ModelCheckpoint's behavior: if `self.save_top_k == 1` only


### PR DESCRIPTION
## What does this PR do?

Previously the MLFlow logger, when the ModelCheckpoint callback was configured without a monitor, was saving `best_model_path` instead of `last_model_path`. Since with no monitor there is no notion of better, this PR corrects this behavior.

Additionally, when a monitor is available, we're storing `best_model_path` as `best.ckpt` to make it easier to access.