### PR TITLE
bugfix/transforms_import

### DIFF
--- a/aics_im2im/image/transforms/__init__.py
+++ b/aics_im2im/image/transforms/__init__.py
@@ -2,4 +2,9 @@ from .bright_sampler import BrightSampler
 from .multiscale_cropper import RandomMultiScaleCropd
 from .o2_mask_transform import O2Mask, O2Maskd
 from .resize import Resized
-from .so2_random_rotation import SO2RandomRotate, SO2RandomRotated
+
+try:
+    from .so2_random_rotation import SO2RandomRotate, SO2RandomRotated
+except ModuleNotFoundError:
+    SO2RandomRotate = None
+    SO2RandomRotated = None


### PR DESCRIPTION
`aics_im2im.image.transforms` imports some transforms which require optional dependencies. this wraps those imports in a try-except block