### PR TITLE
add precision for a100s

### DIFF
--- a/configs/extras/default.yaml
+++ b/configs/extras/default.yaml
@@ -6,3 +6,6 @@ enforce_tags: True
 
 # pretty print config tree at the start of the run using Rich library
 print_config: True
+precision:
+  _target_: torch.set_float32_matmul_precision
+  precision: medium


### PR DESCRIPTION
## What does this PR do?

add medium precision as default in extras. This doesn't seem to break anything when run on non-a100s


## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
