### PR TITLE
Bugfix/minor base model fixes

### DIFF
--- a/aics_im2im/models/base_model.py
+++ b/aics_im2im/models/base_model.py
@@ -137,7 +137,9 @@ class BaseModel(pl.LightningModule, metaclass=BaseModelMeta):
                     if not isinstance(preds, MutableMapping):
                         metric.update(preds, targets)
 
-            self.log(metric_key + "/step", metric, on_step=True, on_epoch=True)
+            self.log(
+                metric_key + "/step", metric.value.detach().item(), on_step=True, on_epoch=False
+            )
             self.log(metric_key, metric, on_step=False, on_epoch=True, prog_bar=True)
 
     def model_step(self, stage, batch, batch_idx):


### PR DESCRIPTION
## What does this PR do?

Prompted by the realization that `SomeModelClasss.load_from_checkpoint` was failing exclusively inside jupyter notebooks, owing to some logic in `lightning`'s `.save_hyperparameters` which expects that method to be called inside the class' `__init__` (which we're not doing). The logic that was causing the errors is unnecessary for us because we are manually cleaning up the hyperparameters that get stored with the model checkpoint, so I'm now explicitly calling `_set_hparams` which is all we need.

Additional minor fixes:
- removed unused import
- made sure validation metrics are empty before the training loop starts (since we might run sanity check val steps before training starts)
- fixed references to `self.scheduler` in `BaseModel`
- set `on_epoch=True` for step-wise metrics as well because otherwise they aren't logged (don't quite understand why)

Fixes #\<issue_number>

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
