### PR TITLE
change backend to aot_eager- default backend not supported on osx

### DIFF
--- a/aics_im2im/models/im2im/multi_task.py
+++ b/aics_im2im/models/im2im/multi_task.py
@@ -63,7 +63,9 @@ class MultiTaskIm2Im(BaseModel):
         for stage in ("train", "val", "test", "predict"):
             (Path(save_dir) / f"{stage}_images").mkdir(exist_ok=True, parents=True)
         self.backbone = torch.compile(backbone, backend="aot_eager")
-        self.task_heads = torch.nn.ModuleDict({k: torch.compile(v, backend="aot_eager") for k, v in task_heads.items()})
+        self.task_heads = torch.nn.ModuleDict(
+            {k: torch.compile(v, backend="aot_eager") for k, v in task_heads.items()}
+        )
 
         for k, head in self.task_heads.items():
             head.update_params({"head_name": k, "x_key": x_key, "save_dir": save_dir})


### PR DESCRIPTION
Fixes https://discuss.pytorch.org/t/torch-compile-seems-to-hang/177089

im2im fails on osx with error 

```
fatal error: 'omp.h' file not found
#include <omp.h>
```
