### PR TITLE
resize images to match in discriminator

### DIFF
--- a/aics_im2im/nn/discriminators/n_layer_discriminator.py
+++ b/aics_im2im/nn/discriminators/n_layer_discriminator.py
@@ -101,9 +101,13 @@ class NLayerDiscriminator(nn.Module):
 
     def forward(self, im, x, requires_features=False):
         """Standard forward."""
-        output_im = [x]
         if self.noise_annealer is not None:
             im = self.noise_annealer(im)
+        if x.shape != im.shape:
+            x = torch.nn.functional.interpolate(
+                input=x,
+                size=im.shape[-3:],
+            )
         output_im = torch.cat([x, im], 1)
         if requires_features:
             results = [output_im]


### PR DESCRIPTION
## What does this PR do?

with multiscale discriminator used in pix2pixhd, images are off by a few pixels, this aligns them.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
