### PR TITLE
bugfix/workflow_compiler_libs_install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt install gcc gfortran libfftw3-dev libblas-dev liblapack-dev
+          sudo apt install gcc gfortran libfftw3-dev libblas-dev liblapack-dev
           python -m pip install --upgrade pip
           pip install wheel
           pip install numpy
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt install gcc gfortran libfftw3-dev libblas-dev liblapack-dev
+          sudo apt install gcc gfortran libfftw3-dev libblas-dev liblapack-dev
           python -m pip install --upgrade pip
           pip install wheel
           pip install numpy


### PR DESCRIPTION
## What does this PR do?

Updates workflows to install some compiler libs before installing python packages. This is needed for some packages that don't release python3.10 wheels.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?
