### PR TITLE
fix python3.10 compatibility in tests. install proper numpy version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,11 @@ jobs:
         shell: bash -el {0}
         run: |
           sudo apt update
-          sudo apt install g++ gfortran libfftw3-dev libblas-dev liblapack-dev
+          sudo apt install -y g++ gfortran libfftw3-dev libblas-dev liblapack-dev
           conda install -n test pip fftw
           pip install wheel
-          pip install numpy
+          # need numpy for some builds. make sure to install a compatible version
+          pip install $(grep -E '^numpy==' requirements/test-requirements.txt)
           # from https://stackoverflow.com/a/14369968
           SETUPTOOLS_USE_DISTUTILS=stdlib pip install -r requirements/test-requirements.txt
           pip install .
@@ -66,10 +67,11 @@ jobs:
         shell: bash -el {0}
         run: |
           sudo apt update
-          sudo apt install g++ gfortran libfftw3-dev libblas-dev liblapack-dev
+          sudo apt install -y g++ gfortran libfftw3-dev libblas-dev liblapack-dev
           conda install -n test pip fftw
           pip install wheel
-          pip install numpy
+          # need numpy for some builds. make sure to install a compatible version
+          pip install $(grep -E '^numpy==' requirements/test-requirements.txt)
           # from https://stackoverflow.com/a/14369968
           SETUPTOOLS_USE_DISTUTILS=stdlib pip install -r requirements/test-requirements.txt
           pip install .


### PR DESCRIPTION
## What does this PR do?

Installs a compatible numpy version before installing the test requirements. This is needed for some packages without wheels but that don't list numpy as a requirement and so their builds fail (e.g. py3nj).

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
