### PR TITLE
generalize multitask dataloader to grouped dataloader

### DIFF
--- a/aics_im2im/datamodules/dataframe/__init__.py
+++ b/aics_im2im/datamodules/dataframe/__init__.py
@@ -1,2 +1,2 @@
 from .dataframe_datamodule import DataframeDatamodule
-from .dataframe_datamodule_multitask import DataframeDatamoduleMultiTask
+from .grouped_dataframe_datamodule import GroupedDataframeDatamodule

--- a/aics_im2im/datamodules/dataframe/dataframe_datamodule.py
+++ b/aics_im2im/datamodules/dataframe/dataframe_datamodule.py
@@ -41,7 +41,6 @@ class DataframeDatamodule(LightningDataModule):
         subsample: Optional[Dict] = None,
         refresh_subsample: bool = False,
         seed: int = 42,
-        target_columns: str = None,
         **dataloader_kwargs,
     ):
         """
@@ -77,9 +76,6 @@ class DataframeDatamodule(LightningDataModule):
             Dictionary with a key per split ("train", "val", "test"), and the
             number of samples of each split to use per epoch. If `None` (default),
             use all the samples in each split per epoch.
-
-        head_allocation_columm: Optional[str]=None
-            Column name that dictates which head a row should be passed to
 
         dataloader_kwargs:
             Additional keyword arguments are passed to the
@@ -127,7 +123,6 @@ class DataframeDatamodule(LightningDataModule):
         else:
             raise FileNotFoundError(f"Could not find specified dataframe path {path}")
 
-        self.target_columns = target_columns
         self.just_inference = just_inference
         self.dataloader_kwargs = dataloader_kwargs
         self.dataloaders = {}

--- a/aics_im2im/datamodules/dataframe/grouped_dataframe_datamodule.py
+++ b/aics_im2im/datamodules/dataframe/grouped_dataframe_datamodule.py
@@ -7,9 +7,14 @@ from .dataframe_datamodule import DataframeDatamodule
 from .utils import AlternatingBatchSampler
 
 
-class DataframeDatamoduleMultiTask(DataframeDatamodule):
-    """A DataframeDatamodule modified for multi-task settings, leveraging an
-    AlternatingBatchSampler."""
+class GroupedDataframeDatamodule(DataframeDatamodule):
+    """A DataframeDatamodule modified for cases where batches should be grouped by some criterion
+    leveraging an AlternatingBatchSampler.
+
+    The two use cases currently supported are 1. multitask training where ground truths are only
+    available for one task at a time and 2. training where batches are grouped by some
+    characteristic of the images.
+    """
 
     def __init__(
         self,
@@ -24,6 +29,7 @@ class DataframeDatamoduleMultiTask(DataframeDatamodule):
         refresh_subsample: bool = False,
         seed: int = 42,
         target_columns: str = None,
+        grouping_column: str = None,
         **dataloader_kwargs,
     ):
         """
@@ -70,6 +76,10 @@ class DataframeDatamoduleMultiTask(DataframeDatamodule):
             column names in csv corresponding to ground truth types to alternate between
             during training
 
+        grouping_column: str = None
+            column names in csv corresponding to a factor that should be homogeneous across
+            a batch
+
         dataloader_kwargs:
             Additional keyword arguments are passed to the
             torch.utils.data.DataLoader class when instantiating it (aside from
@@ -97,6 +107,8 @@ class DataframeDatamoduleMultiTask(DataframeDatamodule):
             seed=seed,
             **dataloader_kwargs,
         )
+        self.group_column = grouping_column
+        self.target_columns = target_columns
 
     def make_dataloader(self, split):
         kwargs = dict(**self.dataloader_kwargs)
@@ -109,5 +121,6 @@ class DataframeDatamoduleMultiTask(DataframeDatamodule):
             drop_last=True,
             shuffle=kwargs.pop("shuffle"),
             target_columns=self.target_columns,
+            grouping_column=self.group_column,
         )
         return DataLoader(dataset=subset, batch_sampler=batch_sampler, **kwargs)


### PR DESCRIPTION
## What does this PR do?
(from BFM, merging now because I need it for other stuff)
generalize multitask datamodule to either present batches with same type of ground truth (original use) or with the same value in some specified grouping column (e.g. pixel size)


## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
