### PR TITLE
fix dtype handling

### DIFF
--- a/aics_im2im/models/im2im/utils/postprocessing/act_thresh_label.py
+++ b/aics_im2im/models/im2im/utils/postprocessing/act_thresh_label.py
@@ -47,7 +47,14 @@ class ActThreshLabel:
             self.dtype = self.rescale_dtype
 
     def _get_dtype(self, dtype: DTypeLike) -> DTypeLike:
-        return get_class(dtype) if dtype is not None else dtype
+        if isinstance(dtype, str):
+            return get_class(dtype)
+        elif dtype is None:
+            return dtype
+        elif isinstance(dtype, type):
+            return dtype
+        else:
+            raise ValueError(f"Expected dtype to be DtypeLike, string, or None, got {type(dtype)}")
 
     def __call__(self, img: torch.Tensor) -> np.ndarray:
         img = self.activation(img[self.ch].detach().cpu().float()).numpy()


### PR DESCRIPTION
## What does this PR do?

if rescale dtype is specified, overwrite dtype
cast dtype string to dtype e.g. 'numpy.uint8'-> numpy.uint8 object

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
