### PR TITLE
bugfix/base_predict_step

### DIFF
--- a/aics_im2im/models/base_model.py
+++ b/aics_im2im/models/base_model.py
@@ -189,9 +189,12 @@ class BaseModel(LightningModule, metaclass=BaseModelMeta):
         return loss
 
     def predict_step(self, batch, batch_idx):
-        loss, preds, targets = self.model_step("predict", batch, batch_idx)
-        self.compute_metrics(loss, preds, targets, "predict")
-        return loss
+        """Here you should implement the logic for an inference step.
+
+        In most cases this would simply consist of calling the forward pass of your model, but you
+        might wish to add additional post-processing.
+        """
+        raise NotImplementedError
 
     def configure_optimizers(self):
         optimizer = self.optimizer(self.parameters())


### PR DESCRIPTION
## What does this PR do?

The `predict_step` in `BaseModel` shouldn't assume that `model_step` makes sense for `predict_step`, if not for anything else, because it shouldn't assume it will have ground truth available in the input, and so most likely won't be able to compute losses. This should be regarded as simply an inference step. This PR adjusts the `BaseModel` class to reflect that.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
