### PR TITLE
feature/config_path_from_env

### DIFF
--- a/cyto_dl/compile.py
+++ b/cyto_dl/compile.py
@@ -100,7 +100,11 @@ def compile(cfg: DictConfig) -> Tuple[dict, dict]:
         package_model(args, manifest=manifest)
 
 
-@hydra.main(version_base="1.3", config_path="../configs", config_name="compile.yaml")
+@hydra.main(
+    version_base="1.3",
+    config_path=os.environ.get("CYTODL_CONFIG_PATH", "../configs"),
+    config_name="compile.yaml",
+)
 def main(cfg: DictConfig) -> None:
     compile(cfg)
 

--- a/cyto_dl/eval.py
+++ b/cyto_dl/eval.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import MutableMapping
 from contextlib import suppress
 from typing import List, Tuple
@@ -90,7 +91,11 @@ def evaluate(cfg: DictConfig) -> Tuple[dict, dict]:
     return metric_dict, object_dict
 
 
-@hydra.main(version_base="1.3", config_path="../configs", config_name="eval.yaml")
+@hydra.main(
+    version_base="1.3",
+    config_path=os.environ.get("CYTODL_CONFIG_PATH", "../configs"),
+    config_name="eval.yaml",
+)
 def main(cfg: DictConfig) -> None:
     evaluate(cfg)
 

--- a/cyto_dl/train.py
+++ b/cyto_dl/train.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import MutableMapping
 from contextlib import suppress
 from pathlib import Path
@@ -117,7 +118,11 @@ def train(cfg: DictConfig) -> Tuple[dict, dict]:
     return metric_dict, object_dict
 
 
-@hydra.main(version_base="1.3", config_path="../configs", config_name="train.yaml")
+@hydra.main(
+    version_base="1.3",
+    config_path=os.environ.get("CYTODL_CONFIG_PATH", "../configs"),
+    config_name="train.yaml",
+)
 def main(cfg: DictConfig) -> Optional[float]:
     if cfg.get("persist_cache", False) or cfg.data.get("cache_dir") is None:
         metric_dict, _ = train(cfg)


### PR DESCRIPTION
## What does this PR do?

Add the option of changing the config path (i.e. the folder where hydra looks for configs) by setting the `CYTODL_CONFIG_PATH` environment variable. Hydra itself already provides a command line flag to do this, but using this environment variable a user only needs to do this once, if they're going to run multiple commands.

Not setting the environment variable defaults to the current behavior.

Fixes #\<issue_number>

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
