### PR TITLE
smaller patch size in skoots default config

### DIFF
--- a/configs/experiment/im2im/skoots.yaml
+++ b/configs/experiment/im2im/skoots.yaml
@@ -33,4 +33,4 @@ data:
   batch_size: 1
 
   _aux:
-    patch_shape: [16, 128, 128]
+    patch_shape: [16, 32, 32]


### PR DESCRIPTION
## What does this PR do?
Reduces the default patch size in the skoots experiment, which we think leads to slowness in tests.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
