### PR TITLE
add postprocesssing

### DIFF
--- a/configs/model/im2im/gan.yaml
+++ b/configs/model/im2im/gan.yaml
@@ -64,3 +64,10 @@ _aux:
         reconstruction_loss:
           _target_: torch.nn.MSELoss
         save_raw: True
+        postprocess:
+          input:
+            _target_: cyto_dl.models.im2im.utils.postprocessing.ActThreshLabel
+            rescale_dtype: numpy.uint8
+          prediction:
+            _target_: cyto_dl.models.im2im.utils.postprocessing.ActThreshLabel
+            rescale_dtype: numpy.uint8

--- a/configs/model/im2im/omnipose.yaml
+++ b/configs/model/im2im/omnipose.yaml
@@ -42,3 +42,10 @@ _aux:
           _target_: cyto_dl.models.im2im.utils.OmniposeLoss
           dim: ${spatial_dims}
         save_raw: True
+        postprocess:
+          input:
+            _target_: cyto_dl.models.im2im.utils.postprocessing.ActThreshLabel
+            dtype: numpy.float32
+          prediction:
+            _target_: cyto_dl.models.im2im.utils.postprocessing.ActThreshLabel
+            dtype: numpy.float32

--- a/configs/model/im2im/skoots.yaml
+++ b/configs/model/im2im/skoots.yaml
@@ -42,3 +42,10 @@ _aux:
           _target_: cyto_dl.models.im2im.utils.SkootsLoss
           dim: ${spatial_dims}
         save_raw: True
+        postprocess:
+          input:
+            _target_: cyto_dl.models.im2im.utils.postprocessing.ActThreshLabel
+            dtype: numpy.float32
+          prediction:
+            _target_: cyto_dl.models.im2im.utils.postprocessing.ActThreshLabel
+            dtype: numpy.float32


### PR DESCRIPTION
aicsimageio can't save float16 images (default dtype with 16bit precision), so all models need a postprocessing method to convert float16 to some other dtype. 

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
