### PR TITLE
set escnn version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ requires-python = ">=3.8,<3.11"
 [project.optional-dependencies]
 equiv = [
     "lie_learn @ git+https://github.com/colobas/lie_learn.git@d5be2ab",
-    "escnn~=1.0.11",
+    "escnn~=1.0.7",
     "e3nn~=0.5.1"
 ]
 spharm = [


### PR DESCRIPTION
## What does this PR do?

Set escnn version to 1.0.7. This is to try and fix build fail errors
