### PR TITLE
pin py3nj to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ requires-python = ">=3.8,<3.11"
 [project.optional-dependencies]
 equiv = [
     "lie_learn @ git+https://github.com/colobas/lie_learn.git@d5be2ab",
-    "escnn==1.0.7",
+    "escnn~=1.0.7",
+    "py3nj==0.1.2",
     "e3nn~=0.5.1"
 ]
 spharm = [


### PR DESCRIPTION
Looked at commit `3e26fee3a417a9918517cea804d08b6bb75e4f95` (tests were last passing here), and `pdm.lock` sets `py3nj` to version `0.1.2`. All builds are currently failing because lock file sets `py3nj` to version `0.2.1`. Initially thought pinning `escnn` to `1.0.7` (instead of `1.0.11`) would fix this, but this did not. Local install with `0.1.2` works fine.

## Did you have fun?

Make sure you had fun coding 🙃
