### PR TITLE
Prediction Saving Improvements

### DIFF
--- a/configs/data/im2im/instance_seg.yaml
+++ b/configs/data/im2im/instance_seg.yaml
@@ -131,7 +131,7 @@ transforms:
           - ${source_col}
         zoom: 0.25
         keep_size: False
-        mode: ["area", "nearest"]
+        mode: ["area"]
       - _target_: monai.transforms.ToTensord
         keys: ${source_col}
       - _target_: monai.transforms.NormalizeIntensityd

--- a/cyto_dl/models/im2im/multi_task.py
+++ b/cyto_dl/models/im2im/multi_task.py
@@ -67,8 +67,6 @@ class MultiTaskIm2Im(BaseModel):
         super().__init__(metrics=metrics, **base_kwargs)
 
         self.automatic_optimization = True
-        for stage in ("train", "val", "test", "predict"):
-            (Path(save_dir) / f"{stage}_images").mkdir(exist_ok=True, parents=True)
 
         if compile is True and not sys.platform.startswith("win"):
             self.backbone = torch.compile(backbone)

--- a/cyto_dl/nn/head/base_head.py
+++ b/cyto_dl/nn/head/base_head.py
@@ -48,7 +48,11 @@ class BaseHead(ABC, torch.nn.Module):
         return [self.postprocess[img_type](img[i]) for i in range(img.shape[0])]
 
     def _save(self, fn, img, stage):
-        out_path = Path(self.save_dir) / f"{stage}_images" / fn
+        if stage in ("train", "val", "test"):
+            (Path(self.save_dir) / f"{stage}_images").mkdir(exist_ok=True, parents=True)
+            out_path = Path(self.save_dir) / f"{stage}_images" / fn
+        else:
+            out_path = Path(self.save_dir) / fn
         OmeTiffWriter().save(
             uri=out_path,
             data=img.squeeze(),


### PR DESCRIPTION
## What does this PR do?
- save predicted images directly to user-provided directory, not `directory/predict_images/`
- only create `test_images/train_images/val_images` when used
- fixes #321 

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
