### PR TITLE
Bugfix/equiv padding weightedmse

### DIFF
--- a/cyto_dl/models/base_model.py
+++ b/cyto_dl/models/base_model.py
@@ -61,7 +61,9 @@ class BaseModelMeta(type):
         # instantiate class with instantiated `init_args`
         # hydra doesn't change the original dict, so we can use it after this
         # with `save_hyperparameters`
-        obj = type.__call__(cls, **instantiate(init_args, _recursive_=True, _convert_=True))
+        obj = type.__call__(
+            cls, **instantiate(init_args, _recursive_=True, _convert_=True)
+        )
 
         # make sure only primitives get stored in the ckpt
         ignore = [arg for arg, v in init_args.items() if not _is_primitive(v)]

--- a/cyto_dl/models/base_model.py
+++ b/cyto_dl/models/base_model.py
@@ -61,9 +61,7 @@ class BaseModelMeta(type):
         # instantiate class with instantiated `init_args`
         # hydra doesn't change the original dict, so we can use it after this
         # with `save_hyperparameters`
-        obj = type.__call__(
-            cls, **instantiate(init_args, _recursive_=True, _convert_=True)
-        )
+        obj = type.__call__(cls, **instantiate(init_args, _recursive_=True, _convert_=True))
 
         # make sure only primitives get stored in the ckpt
         ignore = [arg for arg, v in init_args.items() if not _is_primitive(v)]

--- a/cyto_dl/models/vae/base_vae.py
+++ b/cyto_dl/models/vae/base_vae.py
@@ -171,9 +171,7 @@ class BaseVAE(BaseModel):
         rcl_per_input_dimension = {}
         rcl_reduced = {}
         for key in xhat.keys():
-            rcl_per_input_dimension[key] = self.reconstruction_loss[key](
-                xhat[key], x[key]
-            )
+            rcl_per_input_dimension[key] = self.reconstruction_loss[key](xhat[key], x[key])
             if len(rcl_per_input_dimension[key].shape) > 0:
                 rcl = (
                     rcl_per_input_dimension[key]
@@ -191,12 +189,9 @@ class BaseVAE(BaseModel):
     def calculate_elbo(self, x, xhat, z):
         rcl_reduced = self.calculate_rcl_dict(x, xhat, z)
         kld_per_part = {
-            part: prior(z[part], mode="kl", reduction="none")
-            for part, prior in self.prior.items()
+            part: prior(z[part], mode="kl", reduction="none") for part, prior in self.prior.items()
         }
-        kld_per_part_summed = {
-            part: kl.sum(dim=-1).mean() for part, kl in kld_per_part.items()
-        }
+        kld_per_part_summed = {part: kl.sum(dim=-1).mean() for part, kl in kld_per_part.items()}
 
         total_kld = sum(kld_per_part_summed.values())
         total_recon = sum(rcl_reduced.values())
@@ -217,9 +212,7 @@ class BaseVAE(BaseModel):
         z = {}
         for part, part_params in z_parts_params.items():
             if part in self.prior:
-                z[part] = self.prior[part](
-                    part_params, mode="sample", inference=inference
-                )
+                z[part] = self.prior[part](part_params, mode="sample", inference=inference)
             else:
                 # if prior for this part isn't in the dict, assume dirac prior
                 # i.e. just return the params, and it won't contribute to kl
@@ -249,9 +242,7 @@ class BaseVAE(BaseModel):
             for part, decoder in self.decoder.items()
         }
 
-    def forward(
-        self, batch, decode=False, inference=True, return_params=False, **kwargs
-    ):
+    def forward(self, batch, decode=False, inference=True, return_params=False, **kwargs):
         is_inference = inference or not self.training
 
         z_params = self.encode(batch, **kwargs)

--- a/cyto_dl/models/vae/image_encoder.py
+++ b/cyto_dl/models/vae/image_encoder.py
@@ -45,9 +45,7 @@ class ImageEncoder(torch.nn.Module):
         self.num_res_units = num_res_units
 
         if group not in ("so2", "so3", None):
-            raise ValueError(
-                f"`gspace` should be one of ('so2', 'so3', None). Got {group!r}"
-            )
+            raise ValueError(f"`gspace` should be one of ('so2', 'so3', None). Got {group!r}")
 
         if group == "so2":
             self.gspace = (
@@ -60,9 +58,7 @@ class ImageEncoder(torch.nn.Module):
                 raise ValueError("The SO3 group only works for spatial_dims=3")
             self.gspace = gspaces.rot3dOnR3(maximum_frequency=maximum_frequency)
         else:
-            self.gspace = (
-                gspaces.trivialOnR2() if spatial_dims == 2 else gspaces.trivialOnR3()
-            )
+            self.gspace = gspaces.trivialOnR2() if spatial_dims == 2 else gspaces.trivialOnR3()
 
         self.in_type = nn.FieldType(self.gspace, [self.gspace.trivial_repr])
 
@@ -286,9 +282,7 @@ class Convolution(nn.EquivariantModule):
 
         scalar_fields = nn.FieldType(gspace, out_channels * [gspace.trivial_repr])
         if type(group).__name__ in ("SO2", "SO3"):
-            vector_fields = nn.FieldType(
-                gspace, out_vector_channels * [gspace.irrep(1)]
-            )
+            vector_fields = nn.FieldType(gspace, out_vector_channels * [gspace.irrep(1)])
             out_type = scalar_fields + vector_fields
         else:
             vector_fields = []

--- a/cyto_dl/models/vae/image_encoder.py
+++ b/cyto_dl/models/vae/image_encoder.py
@@ -45,7 +45,9 @@ class ImageEncoder(torch.nn.Module):
         self.num_res_units = num_res_units
 
         if group not in ("so2", "so3", None):
-            raise ValueError(f"`gspace` should be one of ('so2', 'so3', None). Got {group!r}")
+            raise ValueError(
+                f"`gspace` should be one of ('so2', 'so3', None). Got {group!r}"
+            )
 
         if group == "so2":
             self.gspace = (
@@ -58,7 +60,9 @@ class ImageEncoder(torch.nn.Module):
                 raise ValueError("The SO3 group only works for spatial_dims=3")
             self.gspace = gspaces.rot3dOnR3(maximum_frequency=maximum_frequency)
         else:
-            self.gspace = gspaces.trivialOnR2() if spatial_dims == 2 else gspaces.trivialOnR3()
+            self.gspace = (
+                gspaces.trivialOnR2() if spatial_dims == 2 else gspaces.trivialOnR3()
+            )
 
         self.in_type = nn.FieldType(self.gspace, [self.gspace.trivial_repr])
 
@@ -123,6 +127,8 @@ class ImageEncoder(torch.nn.Module):
                 subunits=self.num_res_units,
                 bias=bias,
             )
+        if padding is None:
+            padding = same_padding(kernel_size)
 
         return Convolution(
             spatial_dims=self.spatial_dims,
@@ -280,7 +286,9 @@ class Convolution(nn.EquivariantModule):
 
         scalar_fields = nn.FieldType(gspace, out_channels * [gspace.trivial_repr])
         if type(group).__name__ in ("SO2", "SO3"):
-            vector_fields = nn.FieldType(gspace, out_vector_channels * [gspace.irrep(1)])
+            vector_fields = nn.FieldType(
+                gspace, out_vector_channels * [gspace.irrep(1)]
+            )
             out_type = scalar_fields + vector_fields
         else:
             vector_fields = []

--- a/cyto_dl/models/vae/image_vae.py
+++ b/cyto_dl/models/vae/image_vae.py
@@ -127,9 +127,7 @@ class ImageVAE(BaseVAE):
         assert len(_strides) + 1 == len(_channels)
 
         decode_blocks = []
-        for i, (s, c_in, c_out) in enumerate(
-            zip(_strides, _channels[:-1], _channels[1:])
-        ):
+        for i, (s, c_in, c_out) in enumerate(zip(_strides, _channels[:-1], _channels[1:])):
             last_block = i + 1 == len(_strides)
 
             size = None if not last_block else in_shape
@@ -164,9 +162,7 @@ class ImageVAE(BaseVAE):
 
             decode_blocks.append(nn.Sequential(upsample, res))
 
-        init_shape = (
-            self.final_size if decoder_initial_shape is None else decoder_initial_shape
-        )
+        init_shape = self.final_size if decoder_initial_shape is None else decoder_initial_shape
 
         first_upsample = nn.Sequential(
             nn.Linear(latent_dim, _channels[0] * int(np.product(init_shape))),
@@ -204,9 +200,7 @@ class ImageVAE(BaseVAE):
         )
 
         if group is not None:
-            self.rotation_module = RotationModule(
-                group, spatial_dims, background_value, eps
-            )
+            self.rotation_module = RotationModule(group, spatial_dims, background_value, eps)
         else:
             self.rotation_module = None
 

--- a/cyto_dl/nn/losses/weighted_mse_loss.py
+++ b/cyto_dl/nn/losses/weighted_mse_loss.py
@@ -6,13 +6,26 @@ from torch.nn.modules.loss import _Loss as Loss
 
 
 class WeightedMSELoss(Loss):
-    def __init__(self, reduction="none", weights=1):
+    def __init__(self, reduction="none"):
         super().__init__(None, None, reduction)
         self.reduction = reduction
-        self.weights = torch.tensor(weights).unsqueeze(0)
+        # self.weights = torch.tensor(weights).unsqueeze(0)
+        self.bins = torch.linspace(-2, 2, steps=21)
+        self.bins = [(i, j) for i, j, in zip(self.bins, self.bins[1:])]
+        self.weights = list(torch.linspace(0, 100, steps=11)) + list(
+            torch.linspace(100, 0, steps=11)
+        )
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
-        loss = F.mse_loss(input, target, reduction="none") * self.weights
+        weights = torch.ones(*input.shape)
+        for j, bin in enumerate(self.bins):
+            bin_1 = bin[0]
+            bin_2 = bin[1]
+            this_mask = (input > bin_1) & (input < bin_2)
+            weights[this_mask] = self.weights[j]
+
+        loss = F.mse_loss(input, target, reduction="none")
+        loss = loss * weights.type_as(loss)
 
         if self.reduction == "mean":
             loss = loss.mean(axis=1)


### PR DESCRIPTION
## What does this PR do?

This PR adds a temporary fix to `vae/image_encoder` where `Convolution` class expects padding values to be tuple or int (cannot pass None). The main issue here is that `ResBlock` isn't returning the correct number of vector features that need to be used to compute the pose. 

https://github.com/AllenCellModeling/cyto-dl/blob/dc301551d3c1126fbba3b51cc6dbfff6643b0cd9/cyto_dl/models/vae/image_encoder.py#L165

Here `y_pose` needs to be a 3D vector, but resblocks return multidimensional vectors.

 For now the fix is to not use `ResBlock` and set `num_res_units` to 0.

Also added a weighted mse loss to try to focus the SDF models on the zero level set region. 

https://github.com/AllenCellModeling/cyto-dl/blob/dc301551d3c1126fbba3b51cc6dbfff6643b0cd9/cyto_dl/nn/losses/weighted_mse_loss.py#L19

Also includes some additional args to PC VAE

Fixes #\<issue_number>

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
