### PR TITLE
Add save config function

### DIFF
--- a/cyto_dl/api/model.py
+++ b/cyto_dl/api/model.py
@@ -75,7 +75,6 @@ class CytoDLModel:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         self.cfg = cfg
-        OmegaConf.save(self.cfg, output_dir / f'{"train" if train else "eval"}_config.yaml')
 
     def print_config(self):
         print_config_tree(self.cfg, resolve=True)
@@ -87,6 +86,13 @@ class CytoDLModel:
 
         for k, v in overrides.items():
             OmegaConf.update(self.cfg, k, v)
+
+    def save_config(self, path: Path) -> None:
+        """Save current config to provided path.
+
+        :param path: path at which to save config
+        """
+        OmegaConf.save(self.cfg, path)
 
     async def _train_async(self):
         return train_model(self.cfg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "astropy>=5.2",
     "rich",
     "boto3",
-    "bioio",
+    "bioio>=1.0.1",
     "bioio-czi",
     "bioio-ome-tiff",
     "bioio-tifffile"

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -14,7 +14,7 @@ def test_load_default_experiment_valid_exp_type(MockMkdir, MockSave):
     model: CytoDLModel = CytoDLModel()
     model.load_default_experiment(ExperimentType.SEGMENTATION.value, "fake_dir")
     MockMkdir.assert_called()
-    MockSave.assert_called()
+    MockSave.assert_not_called()
 
 
 @patch("cyto_dl.api.model.OmegaConf.save")


### PR DESCRIPTION
## What does this PR do?
This PR addresses a few of the issues with cyto-dl/plugin integration that we uncovered on Friday.

1. Require a new version of `bioio`
2. Add a `save_config` function to the existing API so that we can save the config with the overrides, not just the default config

## Testing
I tested these changes on a sandbox branch of the plugin, manually verifying that prediction could be started up with a config saved using `save_config` during training.

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
