### PR TITLE
allow continuation of model training

### DIFF
--- a/cyto_dl/train.py
+++ b/cyto_dl/train.py
@@ -97,9 +97,11 @@ def train(cfg: DictConfig) -> Tuple[dict, dict]:
         log.info("Starting training!")
 
         if cfg.get("weights_only"):
+            assert cfg.get(
+                "ckpt_path"
+            ), "ckpt_path must be provided to with argument weights_only=True"
             # load model from state dict to get around trainer.max_epochs limit, useful for resuming model training from existing weights
-            ckpt_path = cfg.get("ckpt_path")
-            state_dict = torch.load(ckpt_path)["state_dict"]
+            state_dict = torch.load(cfg["ckpt_path"])["state_dict"]
             model.load_state_dict(state_dict)
             cfg["ckpt_path"] = None
 


### PR DESCRIPTION
## What does this PR do?
- allow passing of `weights_only` top-level config arg to resume training from model weights (ignoring lightning optimizer metadata etc.)

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
