### PR TITLE
:rocket: Added plugin support for multi-channel segmentations

### DIFF
--- a/configs/data/im2im/segmentation_plugin.yaml
+++ b/configs/data/im2im/segmentation_plugin.yaml
@@ -33,14 +33,16 @@ transforms:
         reader:
           - _target_: cyto_dl.image.io.MonaiBioReader
             dimension_order_out: ${eval:'"CZYX" if ${spatial_dims}==3 else "CYX"'}
-            C: 0
+            # [TRAIN] Exposing C as a configurable param for multi-channel segs
+            C: ${target_col1_channel}
       - _target_: monai.transforms.LoadImaged
         keys: ${target_col2}
         allow_missing_keys: True
         reader:
           - _target_: cyto_dl.image.io.MonaiBioReader
             dimension_order_out: ${eval:'"CZYX" if ${spatial_dims}==3 else "CYX"'}
-            C: 0
+            # [TRAIN] Exposing C as a configurable param for multi-channel segs
+            C:  ${target_col2_channel}
       - _target_: monai.transforms.ThresholdIntensityd
         allow_missing_keys: True
         keys:
@@ -108,14 +110,16 @@ transforms:
         reader:
           - _target_: cyto_dl.image.io.MonaiBioReader
             dimension_order_out: ${eval:'"CZYX" if ${spatial_dims}==3 else "CYX"'}
-            C: 0
+            # [TEST] Exposing C as a configurable param for multi-channel segs
+            C: ${target_col1_channel}
       - _target_: monai.transforms.LoadImaged
         keys: ${target_col2}
         allow_missing_keys: True
         reader:
           - _target_: cyto_dl.image.io.MonaiBioReader
             dimension_order_out: ${eval:'"CZYX" if ${spatial_dims}==3 else "CYX"'}
-            C: 0
+            # [TEST] Exposing C as a configurable param for multi-channel segs
+            C: ${target_col2_channel}
       # load merging mask - assumed not to exist by default
       - _target_: cyto_dl.image.io.PolygonLoaderd
         keys:
@@ -184,14 +188,16 @@ transforms:
         reader:
           - _target_: cyto_dl.image.io.MonaiBioReader
             dimension_order_out: ${eval:'"CZYX" if ${spatial_dims}==3 else "CYX"'}
-            C: 0
+            # [VAL] Exposing C as a configurable param for multi-channel segs
+            C: ${target_col1_channel}
       - _target_: monai.transforms.LoadImaged
         keys: ${target_col2}
         allow_missing_keys: True
         reader:
           - _target_: cyto_dl.image.io.MonaiBioReader
             dimension_order_out: ${eval:'"CZYX" if ${spatial_dims}==3 else "CYX"'}
-            C: 0
+            # [VAL] Exposing C as a configurable param for multi-channel segs
+            C: ${target_col2_channel}
 
       - _target_: monai.transforms.ThresholdIntensityd
         allow_missing_keys: True

--- a/configs/data/im2im/segmentation_plugin.yaml
+++ b/configs/data/im2im/segmentation_plugin.yaml
@@ -42,7 +42,7 @@ transforms:
           - _target_: cyto_dl.image.io.MonaiBioReader
             dimension_order_out: ${eval:'"CZYX" if ${spatial_dims}==3 else "CYX"'}
             # [TRAIN] Exposing C as a configurable param for multi-channel segs
-            C:  ${target_col2_channel}
+            C: ${target_col2_channel}
       - _target_: monai.transforms.ThresholdIntensityd
         allow_missing_keys: True
         keys:

--- a/configs/experiment/im2im/segmentation_plugin.yaml
+++ b/configs/experiment/im2im/segmentation_plugin.yaml
@@ -29,6 +29,8 @@ test: False
 source_col: raw
 target_col1: seg1
 target_col2: seg2
+target_col1_channel: 0
+target_col2_channel: 0
 merge_mask_col: merge_mask
 exclude_mask_col: exclude_mask
 base_image_col: base_image


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fixes #387 
Resolves AllenCell/allencell-ml-segmenter#374

This PR provides multi-channel segmentation support for the Cyto-DL segmentation plugin config. Before, we had hardcoded values `0` for the segmentation channel. These now are comprised of two configurable variables for the channels.

### Breaking Changes

None that I foresee since this only affects the plugin config.

## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [X] Did you **test your PR locally** with `pytest` command?
- [X] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

SO MUCH fun coding 🙃
