### PR TITLE
Make saving requirements optional

### DIFF
--- a/cyto_dl/utils/template_utils.py
+++ b/cyto_dl/utils/template_utils.py
@@ -184,8 +184,12 @@ def log_hyperparameters(object_dict: dict) -> None:
     hparams["ckpt_path"] = cfg.get("ckpt_path")
     hparams["seed"] = cfg.get("seed")
 
-    reqs = subprocess.check_output([sys.executable, "-m", "pip", "freeze"])  # nosec: B603
-    hparams["requirements"] = str(reqs).split("\\n")
+    try:
+        reqs = subprocess.check_output([sys.executable, "-m", "pip", "freeze"])  # nosec: B603
+        hparams["requirements"] = str(reqs).split("\\n")
+    except subprocess.CalledProcessError:
+        # not mandatory to save requirements; allows segmenter plugin devs to use PDM
+        pass
 
     # send hparams to all loggers
     for logger in trainer.loggers:


### PR DESCRIPTION
## What does this PR do?

Makes saving requirements to hparams.yaml using pip freeze optional. This is in order to allow plugin devs to use PDM. Tested with an editable cyto-dl install + plugin and pdm, and this change seems to work.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
