### PR TITLE
Feature/auto batch size find

### DIFF
--- a/configs/experiment/im2im/segmentation_plugin.yaml
+++ b/configs/experiment/im2im/segmentation_plugin.yaml
@@ -52,7 +52,7 @@ data:
   cache_dir: ${paths.output_dir}/cache # string path to cache_dir (this speeds up data loading)
   num_workers: MUST_OVERRIDE # this should be set based on the number of available CPU cores
   split_column: null
-  batch_size: 1
+  batch_size: AUTO # this will use the automatic batch finder starting with batch_size=1
   _aux:
     patch_shape: [16, 32, 32]
 

--- a/cyto_dl/train.py
+++ b/cyto_dl/train.py
@@ -60,7 +60,7 @@ def train(cfg: DictConfig, data=None) -> Tuple[dict, dict]:
     log.info(f"Instantiating data <{cfg.data.get('_target_', cfg.data)}>")
 
     use_batch_tuner = False
-    if cfg.data.batch_size == "AUTO":
+    if cfg.data.get("batch_size") == "AUTO":
         use_batch_tuner = True
         cfg.data.batch_size = 1
 

--- a/cyto_dl/train.py
+++ b/cyto_dl/train.py
@@ -11,6 +11,7 @@ import pyrootutils
 import torch
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers.logger import Logger
+from lightning.pytorch.tuner import Tuner
 from omegaconf import DictConfig, OmegaConf
 
 from cyto_dl import utils
@@ -57,6 +58,12 @@ def train(cfg: DictConfig, data=None) -> Tuple[dict, dict]:
     utils.remove_aux_key(cfg)
 
     log.info(f"Instantiating data <{cfg.data.get('_target_', cfg.data)}>")
+
+    use_batch_tuner = False
+    if cfg.data.batch_size == "AUTO":
+        use_batch_tuner = True
+        cfg.data.batch_size = 1
+
     data = utils.create_dataloader(cfg.data, data)
     if not isinstance(data, LightningDataModule):
         if not isinstance(data, MutableMapping) or "train_dataloaders" not in data:
@@ -92,6 +99,10 @@ def train(cfg: DictConfig, data=None) -> Tuple[dict, dict]:
     if logger:
         log.info("Logging hyperparameters!")
         utils.log_hyperparameters(object_dict)
+
+    if use_batch_tuner:
+        tuner = Tuner(trainer=trainer)
+        tuner.scale_batch_size(model, datamodule=data, mode="power")
 
     if cfg.get("train"):
         log.info("Starting training!")


### PR DESCRIPTION
## What does this PR do?
The auto batch size finder increases the batch size by powers of 2 (starting with batch-size=1) by setting the datamodule's `batch_size` attribute. This PR allows *just* the dataframe datamodule (I think the only one used by the plugin) to respond to its batch_size attribute being changed. In order to do this, we store the initial batch size (set to 1) and check for changes to the batch size to update the train dataloaders. 

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
