### PR TITLE
load ckpt to cpu

### DIFF
--- a/cyto_dl/utils/checkpoint.py
+++ b/cyto_dl/utils/checkpoint.py
@@ -7,7 +7,7 @@ def load_checkpoint(model, load_params):
             "ckpt_path"
         ), "ckpt_path must be provided to with argument weights_only=True"
         # load model from state dict to get around trainer.max_epochs limit, useful for resuming model training from existing weights
-        state_dict = torch.load(load_params["ckpt_path"])["state_dict"]
+        state_dict = torch.load(load_params["ckpt_path"], map_location='cpu')["state_dict"]
         model.load_state_dict(state_dict, strict=load_params.get("strict", True))
         # set ckpt_path to None to avoid loading checkpoint again with model.fit/model.test
         load_params["ckpt_path"] = None

--- a/cyto_dl/utils/checkpoint.py
+++ b/cyto_dl/utils/checkpoint.py
@@ -7,7 +7,7 @@ def load_checkpoint(model, load_params):
             "ckpt_path"
         ), "ckpt_path must be provided to with argument weights_only=True"
         # load model from state dict to get around trainer.max_epochs limit, useful for resuming model training from existing weights
-        state_dict = torch.load(load_params["ckpt_path"], map_location='cpu')["state_dict"]
+        state_dict = torch.load(load_params["ckpt_path"], map_location="cpu")["state_dict"]
         model.load_state_dict(state_dict, strict=load_params.get("strict", True))
         # set ckpt_path to None to avoid loading checkpoint again with model.fit/model.test
         load_params["ckpt_path"] = None


### PR DESCRIPTION
## What does this PR do?
When loading weights from checkpoint, default to cpu. Once the weights are loaded, lightning will move the model to the appropriate device. 


## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
