### PR TITLE
Add filename metadata to multidimdataloader

### DIFF
--- a/configs/data/local/segmentation_all_cells_mask_from_zarr.yaml
+++ b/configs/data/local/segmentation_all_cells_mask_from_zarr.yaml
@@ -5,7 +5,6 @@ batch_size: 1
 pin_memory: True
 #persistent_workers: False
 
-
 csv_path:
 img_path_column: movie_path
 channel_column: bf_channel
@@ -14,5 +13,3 @@ out_key: ${source_col}
 transforms:
   - _target_: monai.transforms.ToTensor
   - _target_: monai.transforms.NormalizeIntensity
-
-

--- a/configs/experiment/local/eval_scale1_new.yaml
+++ b/configs/experiment/local/eval_scale1_new.yaml
@@ -28,17 +28,17 @@ trainer:
 
 model:
   compile: True
-  #save_dir: /allen/aics/assay-dev/users/Suraj/EMT_Work/image_analysis_test/EMT_image_analysis/Colony_mask_training_inference/eval_whole_movie_multiscale_patch1_zarr_aws
+  save_dir: /allen/aics/assay-dev/users/Suraj/EMT_Work/image_analysis_test/EMT_image_analysis/Colony_mask_training_inference/eval_whole_movie_multiscale_patch1_zarr_aws
 
 data:
   csv_path: /allen/aics/assay-dev/users/Suraj/EMT_Work/image_analysis_test/EMT_image_analysis/Colony_mask_training_inference/sample_csv/predict_all_cells_mask_zarr_aws_v0.csv #path to csv containing test movies
   #batch_size: 1
-  _aux: 
+  _aux:
     patch_shape: [16, 128, 128]
 
 callbacks:
   predict_saving:
     _target_: cyto_dl.callbacks.ImageSaver
-    save_dir: /allen/aics/assay-dev/users/Suraj/EMT_Work/image_analysis_test/EMT_image_analysis/Colony_mask_training_inference/eval_whole_movie_multiscale_patch1_zarr_aws
+    save_dir: ${model.save_dir}
     stages: ["predict"]
     save_input: False

--- a/configs/model/local/segmentation_all_cells_mask.yaml
+++ b/configs/model/local/segmentation_all_cells_mask.yaml
@@ -41,7 +41,7 @@ _aux:
     - - ${target_col}
       - _target_: cyto_dl.nn.BaseHead
         loss:
-          _target_: monai.losses.GeneralizedDiceFocalLoss  ##Main loss
+          _target_: monai.losses.GeneralizedDiceFocalLoss ##Main loss
           sigmoid: True
         postprocess:
           input:

--- a/cyto_dl/callbacks/image_saver.py
+++ b/cyto_dl/callbacks/image_saver.py
@@ -19,9 +19,9 @@ class ImageSaver(Callback):
 
         Parameters
         ----------
-        save_dir: Union[str, Path] 
+        save_dir: Union[str, Path]
             Directory to save images. Only testing saves in this directory, prediction
-            saves in model save directory 
+            saves in model save directory
         save_every_n_epochs:int=1
             Frequency to save images
         stages:List[str]=["train", "val"]

--- a/cyto_dl/callbacks/image_saver.py
+++ b/cyto_dl/callbacks/image_saver.py
@@ -19,8 +19,9 @@ class ImageSaver(Callback):
 
         Parameters
         ----------
-        save_dir: Union[str, Path]
-            Directory to save images
+        save_dir: Union[str, Path] 
+            Directory to save images. Only testing saves in this directory, prediction
+            saves in model save directory 
         save_every_n_epochs:int=1
             Frequency to save images
         stages:List[str]=["train", "val"]
@@ -49,6 +50,7 @@ class ImageSaver(Callback):
             if outputs is None:
                 # image has already been saved
                 return
+
             for i, head_io_map in enumerate(io_map.values()):
                 for k, save_path in head_io_map.items():
                     self._save(save_path, outputs[k]["pred"][i])

--- a/cyto_dl/datamodules/multidim_image.py
+++ b/cyto_dl/datamodules/multidim_image.py
@@ -120,7 +120,7 @@ class MultiDimImageDataset(Dataset):
                             "scene": scene,
                             "T": timepoint,
                             "original_path": row[self.img_path_column],
-                            "filename_or_obj": filename,  # needs to be part of metadata to generate IO maps
+                            "filename_or_obj": filename + f"_{timepoint}",  # needs to be part of metadata to generate IO maps
                         }
                     )
         img_data.reverse()

--- a/cyto_dl/datamodules/multidim_image.py
+++ b/cyto_dl/datamodules/multidim_image.py
@@ -97,6 +97,9 @@ class MultiDimImageDataset(Dataset):
         step = row.get(self.time_step_column, 1)
         timepoints = range(start, stop + 1, step) if stop > 0 else range(img.dims.T)
         return list(timepoints)
+    
+    def _get_filename(self, image_input_path):
+        return image_input_path.split('/')[-1].split('.')[0]
 
     def get_per_file_args(self, df):
         img_data = []
@@ -105,6 +108,8 @@ class MultiDimImageDataset(Dataset):
             img = BioImage(row[self.img_path_column])
             scenes = self._get_scenes(row, img)
             timepoints = self._get_timepoints(row, img)
+            filename = self._get_filename(row[self.img_path_column])
+
             for scene in scenes:
                 for timepoint in timepoints:
                     img_data.append(
@@ -115,6 +120,7 @@ class MultiDimImageDataset(Dataset):
                             "scene": scene,
                             "T": timepoint,
                             "original_path": row[self.img_path_column],
+                            "filename_or_obj": filename, # needs to be part of metadata to generate IO maps
                         }
                     )
         img_data.reverse()

--- a/cyto_dl/datamodules/multidim_image.py
+++ b/cyto_dl/datamodules/multidim_image.py
@@ -97,9 +97,9 @@ class MultiDimImageDataset(Dataset):
         step = row.get(self.time_step_column, 1)
         timepoints = range(start, stop + 1, step) if stop > 0 else range(img.dims.T)
         return list(timepoints)
-    
+
     def _get_filename(self, image_input_path):
-        return image_input_path.split('/')[-1].split('.')[0]
+        return image_input_path.split("/")[-1].split(".")[0]
 
     def get_per_file_args(self, df):
         img_data = []
@@ -120,7 +120,7 @@ class MultiDimImageDataset(Dataset):
                             "scene": scene,
                             "T": timepoint,
                             "original_path": row[self.img_path_column],
-                            "filename_or_obj": filename, # needs to be part of metadata to generate IO maps
+                            "filename_or_obj": filename,  # needs to be part of metadata to generate IO maps
                         }
                     )
         img_data.reverse()


### PR DESCRIPTION
## What does this PR do?

Adds `filename_or_obj` metadata when creating the data loader. This is necessary to generate io maps for `MultiTaskIm2Im`.
Testing:

Successfully ran `python cyto_dl.eval.py experiment=local-eval_scale1_new` with save_dir changed to my local directory. Saved a prediction for each timepoint
