### PR TITLE
Default to strict=True for plugin config, add overlap

### DIFF
--- a/configs/experiment/im2im/segmentation_plugin.yaml
+++ b/configs/experiment/im2im/segmentation_plugin.yaml
@@ -63,7 +63,7 @@ paths:
 model:
   _aux:
     filters: MUST_OVERRIDE
-    overlap: 0
+    overlap: 0.2
 
 callbacks:
   # prediction


### PR DESCRIPTION
## What does this PR do?

- Changes the default `segmentation_plugin` config to use `strict=True`, `weights_only=False` by default. 
- Adding a .2 overlap, as discussed with @smishra3 
