### PR TITLE
Remove unnecessary images

### DIFF
--- a/configs/data/im2im/segmentation_plugin.yaml
+++ b/configs/data/im2im/segmentation_plugin.yaml
@@ -76,6 +76,13 @@ transforms:
         base_image_key: ${base_image_col}
         output_name: seg
 
+      # remove keys that aren't used for training (e.g. the pre-merged targets)
+      - _target_: monai.transforms.SelectItemsd
+        keys:
+          - ${source_col}
+          - seg
+          - ${exclude_mask_col}
+
       - _target_: monai.transforms.ToTensord
         keys:
           - ${source_col}
@@ -233,6 +240,13 @@ transforms:
           - ${target_col2}
         base_image_key: ${base_image_col}
         output_name: seg
+
+      # remove keys that aren't used for training (e.g. the pre-merged targets)
+      - _target_: monai.transforms.SelectItemsd
+        keys:
+          - ${source_col}
+          - seg
+          - ${exclude_mask_col}
 
       - _target_: monai.transforms.ToTensord
         keys:


### PR DESCRIPTION
## What does this PR do?
Thao's bug where images of different sizes were being combined in a single batch came from the `target1` and `target2` images being kept around, even after they had been merged into the single ground truth that's actually used for training. Adding the `SelectItemsd` transform will remove these images, only keeping the images that we need (which will be cropped to `patch_size` and so consistent across a batch)


## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
