### PR TITLE
add predict to saving callback

### DIFF
--- a/configs/experiment/im2im/segmentation_plugin.yaml
+++ b/configs/experiment/im2im/segmentation_plugin.yaml
@@ -78,5 +78,5 @@ callbacks:
     _target_: cyto_dl.callbacks.ImageSaver
     save_dir: ${paths.output_dir}
     save_every_n_epochs: ${model.save_images_every_n_epochs}
-    stages: ["train", "test", "val"]
+    stages: ["train", "test", "val", "predict"]
     save_input: True


### PR DESCRIPTION
## What does this PR do?
Adds "predict" to the saving callback so that predictions get saved when using the segmentation_plugin configs
This should fix the current QC issue that thao is having where her images are not being saved after a successful prediction run
Tested locally on windows- working