### PR TITLE
Allow numpy array passed into autothresholding function

### DIFF
--- a/cyto_dl/models/im2im/utils/postprocessing/auto_thresh.py
+++ b/cyto_dl/models/im2im/utils/postprocessing/auto_thresh.py
@@ -23,7 +23,10 @@ class AutoThreshold:
         self.thresh_func = thresh_func
 
     def __call__(self, image):
-        image = image.detach().cpu().float().numpy()
+        # Only get numpy array from torch tensor if tensor is passed in
+        # Allows np.ndarray to be passed in directly
+        if not isinstance(image, np.ndarray):
+            image = image.detach().cpu().float().numpy()
         if self.thresh_func is None:
             return image
         return (image > self.thresh_func(image)).astype(np.uint8)


### PR DESCRIPTION
## What does this PR do?
Allows numpy arrays to be passed into the auththresholding function in `AutoThresh.py` while still allowing torch tensors as before.

Allows thresholding to work properly
