### PR TITLE
Upgrade setup-pdm action

### DIFF
--- a/.github/workflows/make-requirements.yml
+++ b/.github/workflows/make-requirements.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up PDM
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@deb8d8a4e2a03aabcef6f2cc981923fc6b29ef99 # v4.3
         with:
           python-version: "3.10"
           version: 2.18.1


### PR DESCRIPTION
# Purpose
Fix the Make Requirements action which was broken due to (I think) incompatible python versions.

# Changes
Upgrade the setup-pdm action to the latest

# Testing
Successful run of the action here: https://github.com/AllenCellModeling/cyto-dl/actions/runs/14543498742
