### PR TITLE
Fixed bug where trying to run model prediction on single timepoint where start = 0 and stop = 0 would evaluate whole timelapse

### DIFF
--- a/cyto_dl/datamodules/multidim_image.py
+++ b/cyto_dl/datamodules/multidim_image.py
@@ -101,7 +101,7 @@ class MultiDimImageDataset(CacheDataset):
         start = row.get(self.time_start_column, 0)
         stop = row.get(self.time_stop_column, -1)
         step = row.get(self.time_step_column, 1)
-        timepoints = range(start, stop + 1, step) if stop > 0 else range(img.dims.T)
+        timepoints = range(start, stop + 1, step) if stop >= 0 else range(img.dims.T)
         return list(timepoints)
 
     def get_per_file_args(self, df):


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

- This PR fixes a bug where, when a CytoDLModel was asked to predict on a single timepoint where T start = 0 and T end = 0, then it would instead evaluate a range including all timepoints.
- Specifically, I was trying to pass a list of coordinates at a specific timepoint to CytoDL to evaluate through a config file and when start and stop were both 0 the whole timelapse would be evaluated (unexpected), but when any other timepoint was chosen only a single timepoint was evaluated (expected).
- There are no new dependencies required for this change.
- I don't think that this change introduces any breaking changes.
- I tried to run pytest locally but it stopped making progress 56% and after 1.5 hours at I gave up (but it passed everything up to that point)
- I ran the pre-commit hooks and they all passed except that `nbstripout` was skipped because "no files to check"

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?
Yes.
