### PR TITLE
fixed bug in `make_array_dataloader`

### DIFF
--- a/cyto_dl/datamodules/array.py
+++ b/cyto_dl/datamodules/array.py
@@ -33,7 +33,8 @@ def make_array_dataloader(
     """
     if isinstance(transforms, (list, tuple, ListConfig)):
         transforms = Compose(transforms)
-    data = OmegaConf.to_object(data)
+    if OmegaConf.is_config(data):
+        data = OmegaConf.to_object(data)
     if isinstance(data, (list, tuple, ListConfig)):
         data = [{source_key: d} if isinstance(d, np.ndarray) else d for d in data]
     elif isinstance(data, np.ndarray):


### PR DESCRIPTION

## What does this PR do?
`make_array_dataloader` would throw an error when trying to pass array, list of arrays, or list of dict of arrays through the `data` argument. The solution (found with @fatwir) was to only perform `OmegaConf.to_object(data)` if `data` was a config, and not if it was an array / list of arrays / etc.
I don't think that this change should have any breaking changes, as the original code was essentially converting a config object to a dict, and was not checking that it was actually taking in a config object.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?
  - I only ran pre-commit on the file I modified
